### PR TITLE
breakable: set the collision in the base class

### DIFF
--- a/Source/Delta/Breakable/BaseBreakable.cpp
+++ b/Source/Delta/Breakable/BaseBreakable.cpp
@@ -8,19 +8,23 @@
 #include "../Common/LogUtil.h"
 
 ABaseBreakable::ABaseBreakable() {
-  {
-    PrimaryActorTick.bCanEverTick = true;
-  }
+  PrimaryActorTick.bCanEverTick = true;
 
-  {
-    GeometryCollectionComponent =
-      CreateDefaultSubobject<UGeometryCollectionComponent>(TEXT("GeometryCollection"));
+  GeometryCollectionComponent = CreateDefaultSubobject<UGeometryCollectionComponent>(TEXT("GeometryCollection"));
+  check(GeometryCollectionComponent);
 
-    check(GeometryCollectionComponent);
-    DELTA_LOG("{}", DeltaFormat("GeometryCollectionComponent created successfully"));
+  GeometryCollectionComponent->bUseSizeSpecificDamageThreshold = false;
+  GeometryCollectionComponent->SetGenerateOverlapEvents(true);
+  GeometryCollectionComponent->SetNotifyRigidBodyCollision(false);
 
-    RootComponent = GeometryCollectionComponent;
-  }
+  GeometryCollectionComponent->SetCollisionProfileName(TEXT("Custom"));
+  GeometryCollectionComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+  GeometryCollectionComponent->SetCollisionObjectType(ECollisionChannel::ECC_Destructible);
+  GeometryCollectionComponent->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Block);
+  GeometryCollectionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_WorldDynamic, ECollisionResponse::ECR_Overlap);
+  GeometryCollectionComponent->UpdateCollisionProfile();
+
+  RootComponent = GeometryCollectionComponent;
 }
 
 void ABaseBreakable::BeginPlay() {

--- a/Source/Delta/Breakable/Pot_A_Complete.cpp
+++ b/Source/Delta/Breakable/Pot_A_Complete.cpp
@@ -7,22 +7,7 @@
 #include "../Common/Finder.h"
 
 APot_A_Complete::APot_A_Complete() {
-  {
-    static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
-                                          "GC_SM_Pot_A_Complete1.GC_SM_Pot_A_Complete1'");
-    DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
-  }
-
-  {
-    GeometryCollectionComponent->bUseSizeSpecificDamageThreshold = false;
-    GeometryCollectionComponent->SetGenerateOverlapEvents(true);
-    GeometryCollectionComponent->SetNotifyRigidBodyCollision(false);
-
-    GeometryCollectionComponent->SetCollisionProfileName(TEXT("Custom"));
-    GeometryCollectionComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-    GeometryCollectionComponent->SetCollisionObjectType(ECollisionChannel::ECC_Destructible);
-    GeometryCollectionComponent->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Block);
-    GeometryCollectionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_WorldDynamic, ECollisionResponse::ECR_Overlap);
-    GeometryCollectionComponent->UpdateCollisionProfile();
-  }
+  static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
+                                        "GC_SM_Pot_A_Complete1.GC_SM_Pot_A_Complete1'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
 }


### PR DESCRIPTION
This pull request refactors the initialization of `UGeometryCollectionComponent` in breakable object classes by consolidating collision setup logic into the base class `ABaseBreakable`. This eliminates duplicate code and ensures consistent collision settings across derived classes.

### Refactoring and code reuse:

* In `Source/Delta/Breakable/BaseBreakable.cpp`, the initialization of `UGeometryCollectionComponent` has been expanded to include detailed collision setup, such as disabling size-specific damage thresholds, enabling overlap events, and configuring collision profiles. This setup is now centralized in the base class.

* In `Source/Delta/Breakable/Pot_A_Complete.cpp`, redundant collision setup logic has been removed from the derived class `APot_A_Complete`, as it is now handled in the base class `ABaseBreakable`.