### PR TITLE
breakable: spwan treasure if hit event is trigged

### DIFF
--- a/Content/Delta/Map/MainMap.umap
+++ b/Content/Delta/Map/MainMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3948577f07a23f171e0fe8fbeae956359b9df8934afaae2dfce72c65aae0add3
-size 343253
+oid sha256:dcf7e0f24c2a7bb116a83c229d6cdf5826339f3dd6ad4d95d5296d183f122777
+size 343351

--- a/Delta.uproject
+++ b/Delta.uproject
@@ -30,6 +30,10 @@
     {
       "Name": "PCGGeometryScriptInterop",
       "Enabled": true
+    },
+    {
+      "Name": "HairStrands",
+      "Enabled": true
     }
   ]
 }

--- a/Source/Delta/Breakable/BaseBreakable.cpp
+++ b/Source/Delta/Breakable/BaseBreakable.cpp
@@ -6,7 +6,9 @@
 #include "GeometryCollection/GeometryCollectionComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "Misc/AssertionMacros.h"
+#include "../Treasure/BaseTreasure.h"
 #include "../Common/LogUtil.h"
+#include "../Common/Finder.h"
 
 ABaseBreakable::ABaseBreakable() {
   PrimaryActorTick.bCanEverTick = true;
@@ -24,10 +26,24 @@ ABaseBreakable::ABaseBreakable() {
   GeometryCollectionComponent->SetCollisionObjectType(ECollisionChannel::ECC_Destructible);
   GeometryCollectionComponent->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Block);
   GeometryCollectionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Camera, ECollisionResponse::ECR_Ignore);
+  GeometryCollectionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Pawn, ECollisionResponse::ECR_Ignore);
   GeometryCollectionComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_WorldDynamic, ECollisionResponse::ECR_Overlap);
   GeometryCollectionComponent->UpdateCollisionProfile();
 
   RootComponent = GeometryCollectionComponent;
+
+  Capsule = CreateDefaultSubobject<UCapsuleComponent>(TEXT("Capsule"));
+  Capsule->SetupAttachment(GetRootComponent());
+
+  Capsule->SetCollisionProfileName(TEXT("Custom"));
+  Capsule->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+  Capsule->SetCollisionObjectType(ECollisionChannel::ECC_WorldDynamic);
+  Capsule->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Ignore);
+  Capsule->SetCollisionResponseToChannel(ECollisionChannel::ECC_Pawn, ECollisionResponse::ECR_Block);
+  Capsule->UpdateCollisionProfile();
+
+  static const TCHAR* const Path = TEXT("/Script/MetasoundEngine.MetaSoundSource'/Game/Delta/MetaSound/sfx_PotBreak.sfx_PotBreak'");
+  DELTA_SET_SOUNDBASE(BreakSound, Path);
 }
 
 void ABaseBreakable::BeginPlay() {
@@ -40,8 +56,27 @@ void ABaseBreakable::GetHit(const FVector& ImpactPoint) {
   DELTA_LOG("[{}] Impact point: {}", DELTA_FUNCSIG, ImpactPoint.ToString());
 #endif
   UGameplayStatics::PlaySoundAtLocation(GetWorld(), BreakSound, ImpactPoint);
+
+  if (UWorld* const World = GetWorld(); World != nullptr && TreasureClasses.Num() > 0) {
+    FVector Location = GetActorLocation();
+    Location.Z += 55.f;
+
+    const int32 Selection = FMath::RandRange(0, TreasureClasses.Num() - 1);
+    World->SpawnActor<ABaseTreasure>(TreasureClasses[Selection], Location, GetActorRotation());
+
+    if (Capsule) {
+      Capsule->DestroyComponent();
+      Capsule = nullptr;
+    }
+  }
 }
 
 void ABaseBreakable::OnBreakEvent(const FChaosBreakEvent& BreakEvent) {
   SetLifeSpan(LifeSpan);
+}
+
+void ABaseBreakable::AddTreasureClass(TSubclassOf<ABaseTreasure> InsertedTreasureClass) {
+  if (InsertedTreasureClass) {
+    TreasureClasses.Add(InsertedTreasureClass);
+  }
 }

--- a/Source/Delta/Breakable/BaseBreakable.cpp
+++ b/Source/Delta/Breakable/BaseBreakable.cpp
@@ -59,7 +59,7 @@ void ABaseBreakable::GetHit(const FVector& ImpactPoint) {
 
   if (UWorld* const World = GetWorld(); World != nullptr && TreasureClasses.Num() > 0) {
     FVector Location = GetActorLocation();
-    Location.Z += 55.f;
+    Location.Z += TreasureSpawnZOffset;
 
     const int32 Selection = FMath::RandRange(0, TreasureClasses.Num() - 1);
     World->SpawnActor<ABaseTreasure>(TreasureClasses[Selection], Location, GetActorRotation());
@@ -76,7 +76,9 @@ void ABaseBreakable::OnBreakEvent(const FChaosBreakEvent& BreakEvent) {
 }
 
 void ABaseBreakable::AddTreasureClass(TSubclassOf<ABaseTreasure> InsertedTreasureClass) {
-  if (InsertedTreasureClass) {
-    TreasureClasses.Add(InsertedTreasureClass);
+  if (InsertedTreasureClass == nullptr) {
+    DELTA_LOG("{}", DeltaFormat("[{}] Inserted treasure class is null!", DELTA_FUNCSIG));
+    return;
   }
+  TreasureClasses.Add(InsertedTreasureClass);
 }

--- a/Source/Delta/Breakable/BaseBreakable.h
+++ b/Source/Delta/Breakable/BaseBreakable.h
@@ -48,4 +48,5 @@ protected:
   TObjectPtr<UCapsuleComponent> Capsule{nullptr};
 
   float LifeSpan{5.5f};
+  float TreasureSpawnZOffset{50.0f};
 };

--- a/Source/Delta/Breakable/BaseBreakable.h
+++ b/Source/Delta/Breakable/BaseBreakable.h
@@ -7,10 +7,13 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "Physics/Experimental/ChaosEventType.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Components/CapsuleComponent.h"
+#include "../Treasure/BaseTreasure.h"
 #include "../Interface/HitInterface.h"
 #include "BaseBreakable.generated.h"
 
-#define DELTA_BREAKABLE_ENABLE_DEBUG_HIT 1
+#define DELTA_BREAKABLE_ENABLE_DEBUG_HIT 0
 
 class UGeometryCollectionComponent;
 class USoundBase;
@@ -27,6 +30,8 @@ public:
   UFUNCTION()
   void OnBreakEvent(const FChaosBreakEvent& BreakEvent);
 
+  void AddTreasureClass(TSubclassOf<ABaseTreasure> InsertedTreasureClass);
+
 protected:
   virtual void BeginPlay() override;
 
@@ -36,5 +41,11 @@ protected:
   UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Sound")
   TObjectPtr<USoundBase> BreakSound{nullptr};
 
-  float LifeSpan{3.5f};
+  UPROPERTY(EditAnywhere, Category = "Breakable Properties")
+  TArray<TSubclassOf<class ABaseTreasure>> TreasureClasses;
+
+  UPROPERTY(EditAnywhere, BlueprintReadWrite)
+  TObjectPtr<UCapsuleComponent> Capsule{nullptr};
+
+  float LifeSpan{5.5f};
 };

--- a/Source/Delta/Breakable/Pot_A_Complete.cpp
+++ b/Source/Delta/Breakable/Pot_A_Complete.cpp
@@ -5,17 +5,17 @@
 #include "Pot_A_Complete.h"
 #include "GeometryCollection/GeometryCollectionComponent.h"
 #include "Sound/SoundBase.h"
+#include "../Treasure/ChaliceTreasure.h"
 #include "../Common/Finder.h"
 
 APot_A_Complete::APot_A_Complete() {
-  {
-    static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
-                                          "GC_SM_Pot_A_Complete1.GC_SM_Pot_A_Complete1'");
-    DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
-  }
+  static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
+                                        "GC_SM_Pot_A_Complete1.GC_SM_Pot_A_Complete1'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
 
-  {
-    static const TCHAR* const Path = TEXT("/Script/MetasoundEngine.MetaSoundSource'/Game/Delta/MetaSound/sfx_PotBreak.sfx_PotBreak'");
-    DELTA_SET_SOUNDBASE(BreakSound, Path);
-  }
+  Capsule->SetRelativeLocation(FVector(0, 0, 81.0));
+  Capsule->SetCapsuleHalfHeight(90.0);
+  Capsule->SetCapsuleRadius(90.0);
+
+  AddTreasureClass(AChaliceTreasure::StaticClass());
 }

--- a/Source/Delta/Treasure/BaseTreasure.cpp
+++ b/Source/Delta/Treasure/BaseTreasure.cpp
@@ -12,6 +12,9 @@ ABaseTreasure::ABaseTreasure() {
   // Sound effect by Eric Matyas - www.soundimage.org
   static const TCHAR* const Path = TEXT("/Script/MetasoundEngine.MetaSoundSource'/Game/Delta/MetaSound/sfx_Treasure.sfx_Treasure'");
   DELTA_SET_SOUNDBASE(PickupSound, Path);
+
+  StaticMeshComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Camera, ECollisionResponse::ECR_Ignore);
+  StaticMeshComponent->UpdateCollisionProfile();
 }
 
 void ABaseTreasure::OnSphereBeginOverlap(UPrimitiveComponent* OverlappedComponent,

--- a/Source/Delta/Weapon/Sword.h
+++ b/Source/Delta/Weapon/Sword.h
@@ -8,7 +8,7 @@
 #include "Weapon.h"
 #include "Sword.generated.h"
 
-#define DELTA_SWORD_ENABLE_DEBUG_HIT               1
+#define DELTA_SWORD_ENABLE_DEBUG_HIT               0
 #define DELTA_SWORD_ENABLE_BLUEPRINT_ATTACK_FIELDS 0
 
 UCLASS()


### PR DESCRIPTION
This pull request introduces several enhancements and new features, primarily focusing on the `ABaseBreakable` class, collision handling, and treasure spawning mechanics. Additionally, it includes minor configuration updates and debug flag changes.

### Enhancements to `ABaseBreakable`:

* Added a `Capsule` component to `ABaseBreakable` for improved collision management, including setup, custom collision profiles, and response configurations. [[1]](diffhunk://#diff-ac1dc3cf5eba0d3271c487867bfcf7ebb2198935a07c522bdf3c43f593d62d6eR29-R46) [[2]](diffhunk://#diff-836a23dc44b4ea25d68ebc8a086b60e77aff1de00faf68cc9f6a1a5a1fa66ac3L39-R50)
* Introduced a `TreasureClasses` array in `ABaseBreakable` to support spawning random treasures upon destruction. A new method, `AddTreasureClass`, was added to populate this array. [[1]](diffhunk://#diff-ac1dc3cf5eba0d3271c487867bfcf7ebb2198935a07c522bdf3c43f593d62d6eR59-R82) [[2]](diffhunk://#diff-836a23dc44b4ea25d68ebc8a086b60e77aff1de00faf68cc9f6a1a5a1fa66ac3R33-R34) [[3]](diffhunk://#diff-836a23dc44b4ea25d68ebc8a086b60e77aff1de00faf68cc9f6a1a5a1fa66ac3L39-R50)
* Updated the lifespan of `ABaseBreakable` from 3.5 to 5.5 seconds.

### Treasure and collision improvements:

* Modified `ABaseTreasure` to ignore camera collisions and updated its collision profile for better interaction handling.
* Adjusted collision responses for `GeometryCollectionComponent` in `ABaseBreakable`, specifically ignoring collisions with pawns.

### Updates to derived classes and assets:

* Updated `APot_A_Complete` to configure the `Capsule` component's dimensions and add a `ChaliceTreasure` to its `TreasureClasses`.
* Updated the `MainMap.umap` file with a new version and size.

### Configuration and debug flag changes:

* Enabled the `HairStrands` plugin in `Delta.uproject`.
* Disabled debug hit flags in both `ABaseBreakable` and `Sword`. [[1]](diffhunk://#diff-836a23dc44b4ea25d68ebc8a086b60e77aff1de00faf68cc9f6a1a5a1fa66ac3R10-R16) [[2]](diffhunk://#diff-b0d437c885aa0385724cafdccc36c8ba5464fa55cd08d2d3be3518cd69dad770L11-R11)