### PR TITLE
breakable: add more types

### DIFF
--- a/Content/Delta/Breakable/BP_ClayPot01Breakable.uasset
+++ b/Content/Delta/Breakable/BP_ClayPot01Breakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e39582cd2aba8f1e4e694c0cdcae81d6d5d7425ac7c16d875142d0622d3bd96
+size 32673

--- a/Content/Delta/Breakable/BP_ClayPot02Breakable.uasset
+++ b/Content/Delta/Breakable/BP_ClayPot02Breakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25e1caa39062149f5a221eb5f54c850a94ccd6bfb81c45007f4928c1d798f5a4
+size 32867

--- a/Content/Delta/Breakable/BP_PotACompleteBreakable.uasset
+++ b/Content/Delta/Breakable/BP_PotACompleteBreakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4580210e492799ff3b3655e98e0131703fc685df98b3c7864a97c318cee0d5b6
+size 34794

--- a/Content/Delta/Breakable/BP_PotBCompleteBreakable.uasset
+++ b/Content/Delta/Breakable/BP_PotBCompleteBreakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffec030673fc5641803f12bc1f6a5f994f1bb1c3730a5f8c77e0098d56d82d89
+size 34558

--- a/Content/Delta/Breakable/BP_PotCCompleteBreakable.uasset
+++ b/Content/Delta/Breakable/BP_PotCCompleteBreakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03348ed2fef3675a3c1c43709d4da27f6fb54bf4f16a0facb99995476a2cd448
+size 32619

--- a/Content/Delta/Breakable/BP_Pot_A_Complete.uasset
+++ b/Content/Delta/Breakable/BP_Pot_A_Complete.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66802b00a20de27b2a416ad1d8b51e407668fb7207c929ce13533dba1b3dc5c6
-size 30135

--- a/Content/Delta/Breakable/BP_Urn01aBreakable.uasset
+++ b/Content/Delta/Breakable/BP_Urn01aBreakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80a3fe04bc31ac5add19bf00fed34950ee257ea5e8b5dc1579795ae33361c5db
+size 36785

--- a/Content/Delta/Breakable/BP_Urn04aBreakable.uasset
+++ b/Content/Delta/Breakable/BP_Urn04aBreakable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a79b334fe217b3cd3c58fc1d7a013273cc7fb0c557df63bbfb7c1a32648d3190
+size 33189

--- a/Content/Delta/Destructible/GC_SM_ClayPot_01.uasset
+++ b/Content/Delta/Destructible/GC_SM_ClayPot_01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:805b9aae92894621de62aeb4657fd184e3d1795becbe5be97c68d46c743be8d2
+size 816543

--- a/Content/Delta/Destructible/GC_SM_ClayPot_02.uasset
+++ b/Content/Delta/Destructible/GC_SM_ClayPot_02.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1218289f3809233583038994a4c31bbb4e3f2d6d042ea931f427305b746e9e28
+size 865956

--- a/Content/Delta/Destructible/GC_SM_Pot_B_Complete.uasset
+++ b/Content/Delta/Destructible/GC_SM_Pot_B_Complete.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05c718b001c6dd74eb817a75cb69ddb60c820057f7140a83ac5aecb66bf8a7f7
+size 2006138

--- a/Content/Delta/Destructible/GC_SM_Pot_C_Complete.uasset
+++ b/Content/Delta/Destructible/GC_SM_Pot_C_Complete.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f7e0235dfe02246eb13bcc0aa094c67340fc0ea4ca5ff65559c69771fb92ad
+size 1999547

--- a/Content/Delta/Destructible/GC_SM_Urn_01a.uasset
+++ b/Content/Delta/Destructible/GC_SM_Urn_01a.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff9b84f49a0fd3b11e748de11ff3a997f27d5e86889590f3940539912bff0c87
+size 2125562

--- a/Content/Delta/Destructible/GC_SM_Urn_04a.uasset
+++ b/Content/Delta/Destructible/GC_SM_Urn_04a.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27cb569211aeea00b932203217fe7eaeb66d83ccd9c9ba0d680ff566832ad08a
+size 910898

--- a/Content/Delta/Item/BP_GargoyleStatueStand.uasset
+++ b/Content/Delta/Item/BP_GargoyleStatueStand.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17b61800266053dbc0829fe5e54d0a8c5597a9e8def424657a744ab90e38731b
+size 35864

--- a/Content/Delta/Map/MainMap.umap
+++ b/Content/Delta/Map/MainMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1276a794befc4725e98a179debcb2574762728c5ee6555cabb6cf2b4008783c1
-size 352244
+oid sha256:0689a4aa4d194d423eb82e314150507a4b1fdc774bf78cb5c71dd78a3e354b45
+size 354714

--- a/Delta.code-workspace
+++ b/Delta.code-workspace
@@ -18,6 +18,9 @@
       "DOTNET_HOST_PATH": "D:\\Epic Games\\UE_5.5\\Engine\\Binaries\\ThirdParty\\DotNet\\8.0.300\\win-x64\\dotnet.exe",
       "DOTNET_MULTILEVEL_LOOKUP": "0",
       "DOTNET_ROLL_FORWARD": "LatestMajor"
+    },
+    "files.associations": {
+      "*.rh": "cpp"
     }
   },
   "extensions": {

--- a/Source/Delta/Breakable/ClayPot01Breakable.cpp
+++ b/Source/Delta/Breakable/ClayPot01Breakable.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "ClayPot01Breakable.h"
+
+AClayPot01Breakable::AClayPot01Breakable() {
+  static const TCHAR* const Path =
+    TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/GC_SM_ClayPot_01.GC_SM_ClayPot_01'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
+
+  Capsule->SetRelativeLocation(FVector(0, 0, 28.0));
+  Capsule->SetCapsuleHalfHeight(57.0);
+  Capsule->SetCapsuleRadius(28.0);
+}

--- a/Source/Delta/Breakable/ClayPot01Breakable.h
+++ b/Source/Delta/Breakable/ClayPot01Breakable.h
@@ -6,12 +6,12 @@
 
 #include "CoreMinimal.h"
 #include "BaseBreakable.h"
-#include "Pot_A_Complete.generated.h"
+#include "ClayPot01Breakable.generated.h"
 
 UCLASS()
-class DELTA_API APot_A_Complete : public ABaseBreakable {
+class DELTA_API AClayPot01Breakable : public ABaseBreakable {
   GENERATED_BODY()
 
 public:
-  APot_A_Complete();
+  AClayPot01Breakable();
 };

--- a/Source/Delta/Breakable/ClayPot02Breakable.cpp
+++ b/Source/Delta/Breakable/ClayPot02Breakable.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "ClayPot02Breakable.h"
+
+AClayPot02Breakable::AClayPot02Breakable() {
+  static const TCHAR* const Path =
+    TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/GC_SM_ClayPot_02.GC_SM_ClayPot_02'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
+
+  Capsule->SetRelativeLocation(FVector(0, 0, 32.0));
+  Capsule->SetCapsuleHalfHeight(52.0);
+  Capsule->SetCapsuleRadius(32.0);
+}

--- a/Source/Delta/Breakable/ClayPot02Breakable.h
+++ b/Source/Delta/Breakable/ClayPot02Breakable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BaseBreakable.h"
+#include "ClayPot02Breakable.generated.h"
+
+UCLASS()
+class DELTA_API AClayPot02Breakable : public ABaseBreakable {
+  GENERATED_BODY()
+
+public:
+  AClayPot02Breakable();
+};

--- a/Source/Delta/Breakable/PotACompleteBreakable.cpp
+++ b/Source/Delta/Breakable/PotACompleteBreakable.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "PotACompleteBreakable.h"
+
+APotACompleteBreakable::APotACompleteBreakable() {
+  static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
+                                        "GC_SM_Pot_A_Complete1.GC_SM_Pot_A_Complete1'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
+
+  Capsule->SetRelativeLocation(FVector(0, 0, 81.0));
+  Capsule->SetCapsuleHalfHeight(90.0);
+  Capsule->SetCapsuleRadius(90.0);
+}

--- a/Source/Delta/Breakable/PotACompleteBreakable.h
+++ b/Source/Delta/Breakable/PotACompleteBreakable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BaseBreakable.h"
+#include "PotACompleteBreakable.generated.h"
+
+UCLASS()
+class DELTA_API APotACompleteBreakable : public ABaseBreakable {
+  GENERATED_BODY()
+
+public:
+  APotACompleteBreakable();
+};

--- a/Source/Delta/Breakable/PotBCompleteBreakable.cpp
+++ b/Source/Delta/Breakable/PotBCompleteBreakable.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "PotBCompleteBreakable.h"
+
+APotBCompleteBreakable::APotBCompleteBreakable() {
+  static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
+                                        "GC_SM_Pot_B_Complete.GC_SM_Pot_B_Complete'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
+
+  Capsule->SetRelativeLocation(FVector(0, 0, 10.0));
+  Capsule->SetCapsuleHalfHeight(20.0);
+  Capsule->SetCapsuleRadius(20.0);
+}

--- a/Source/Delta/Breakable/PotBCompleteBreakable.h
+++ b/Source/Delta/Breakable/PotBCompleteBreakable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BaseBreakable.h"
+#include "PotBCompleteBreakable.generated.h"
+
+UCLASS()
+class DELTA_API APotBCompleteBreakable : public ABaseBreakable {
+  GENERATED_BODY()
+
+public:
+  APotBCompleteBreakable();
+};

--- a/Source/Delta/Breakable/PotCCompleteBreakable.cpp
+++ b/Source/Delta/Breakable/PotCCompleteBreakable.cpp
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 
-#include "Pot_A_Complete.h"
+#include "PotCCompleteBreakable.h"
 
-APot_A_Complete::APot_A_Complete() {
+APotCCompleteBreakable::APotCCompleteBreakable() {
   static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
-                                        "GC_SM_Pot_A_Complete1.GC_SM_Pot_A_Complete1'");
+                                        "GC_SM_Pot_C_Complete.GC_SM_Pot_C_Complete'");
   DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
 
-  Capsule->SetRelativeLocation(FVector(0, 0, 81.0));
-  Capsule->SetCapsuleHalfHeight(90.0);
-  Capsule->SetCapsuleRadius(90.0);
+  Capsule->SetRelativeLocation(FVector(0, 0, 16.0));
+  Capsule->SetCapsuleHalfHeight(25.0);
+  Capsule->SetCapsuleRadius(15.0);
 }

--- a/Source/Delta/Breakable/PotCCompleteBreakable.h
+++ b/Source/Delta/Breakable/PotCCompleteBreakable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BaseBreakable.h"
+#include "PotCCompleteBreakable.generated.h"
+
+UCLASS()
+class DELTA_API APotCCompleteBreakable : public ABaseBreakable {
+  GENERATED_BODY()
+
+public:
+  APotCCompleteBreakable();
+};

--- a/Source/Delta/Breakable/Urn01aBreakable.cpp
+++ b/Source/Delta/Breakable/Urn01aBreakable.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "Urn01aBreakable.h"
+
+AUrn01aBreakable::AUrn01aBreakable() {
+  static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
+                                        "GC_SM_Urn_01a.GC_SM_Urn_01a'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
+
+  Capsule->SetRelativeLocation(FVector(0, 0, 20.0));
+  Capsule->SetCapsuleHalfHeight(35.0);
+  Capsule->SetCapsuleRadius(20.0);
+}

--- a/Source/Delta/Breakable/Urn01aBreakable.h
+++ b/Source/Delta/Breakable/Urn01aBreakable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BaseBreakable.h"
+#include "Urn01aBreakable.generated.h"
+
+UCLASS()
+class DELTA_API AUrn01aBreakable : public ABaseBreakable {
+  GENERATED_BODY()
+
+public:
+  AUrn01aBreakable();
+};

--- a/Source/Delta/Breakable/Urn04aBreakable.cpp
+++ b/Source/Delta/Breakable/Urn04aBreakable.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "Urn04aBreakable.h"
+
+AUrn04aBreakable::AUrn04aBreakable() {
+  static const TCHAR* const Path = TEXT("/Script/GeometryCollectionEngine.GeometryCollection'/Game/Delta/Destructible/"
+                                        "GC_SM_Urn_04a.GC_SM_Urn_04a'");
+  DELTA_SET_GEOMETRY_COLLECTION(GeometryCollectionComponent, Path);
+
+  Capsule->SetRelativeLocation(FVector(0, 0, 60.0));
+  Capsule->SetCapsuleHalfHeight(75.0);
+  Capsule->SetCapsuleRadius(13.0);
+}

--- a/Source/Delta/Breakable/Urn04aBreakable.h
+++ b/Source/Delta/Breakable/Urn04aBreakable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BaseBreakable.h"
+#include "Urn04aBreakable.generated.h"
+
+UCLASS()
+class DELTA_API AUrn04aBreakable : public ABaseBreakable {
+  GENERATED_BODY()
+
+public:
+  AUrn04aBreakable();
+};

--- a/Source/Delta/Item/GargoyleStatueStand.cpp
+++ b/Source/Delta/Item/GargoyleStatueStand.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "GargoyleStatueStand.h"
+#include "Components/SphereComponent.h"
+#include "../Common/Finder.h"
+
+AGargoyleStatueStand::AGargoyleStatueStand() {
+  {
+    static const TCHAR* const Path =
+      TEXT("/Script/Engine.StaticMesh'/Game/MedievalDungeon/Meshes/Props/SM_Gargoyle_Statue_Stand.SM_Gargoyle_Statue_Stand'");
+    DELTA_SET_STATIC_MESH(StaticMeshComponent, Path);
+  }
+
+  {
+    SphereComponent->SetSphereRadius(63.f);
+    SphereComponent->SetRelativeLocation(FVector(0, 0, 36.0f));
+    SphereComponent->SetCollisionProfileName(TEXT("Custom"));
+    SphereComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+    SphereComponent->SetCollisionObjectType(ECollisionChannel::ECC_WorldStatic);
+    SphereComponent->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Block);
+    SphereComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Camera, ECollisionResponse::ECR_Ignore);
+    SphereComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Pawn, ECollisionResponse::ECR_Ignore);
+  }
+
+  {
+    StaticMeshComponent->SetCollisionProfileName(TEXT("Custom"));
+    StaticMeshComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+    StaticMeshComponent->SetCollisionObjectType(ECollisionChannel::ECC_WorldDynamic);
+    StaticMeshComponent->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Block);
+    StaticMeshComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Camera, ECollisionResponse::ECR_Ignore);
+    StaticMeshComponent->SetCollisionResponseToChannel(ECollisionChannel::ECC_Pawn, ECollisionResponse::ECR_Overlap);
+    StaticMeshComponent->UpdateCollisionProfile();
+  }
+}

--- a/Source/Delta/Item/GargoyleStatueStand.h
+++ b/Source/Delta/Item/GargoyleStatueStand.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Item.h"
+#include "GargoyleStatueStand.generated.h"
+
+UCLASS()
+class DELTA_API AGargoyleStatueStand : public AItem {
+  GENERATED_BODY()
+
+public:
+  AGargoyleStatueStand();
+};


### PR DESCRIPTION
This pull request introduces new breakable asset files, destructible geometry collections, and corresponding C++ classes for breakable objects in the Delta project. It also includes updates to the main map, workspace settings, and the removal of an outdated asset file.

### New Breakable Assets and Classes:
* Added new breakable asset files for various objects, including clay pots (`BP_ClayPot01Breakable.uasset`, `BP_ClayPot02Breakable.uasset`), pots (`BP_PotACompleteBreakable.uasset`, `BP_PotBCompleteBreakable.uasset`, `BP_PotCCompleteBreakable.uasset`), and urns (`BP_Urn01aBreakable.uasset`, `BP_Urn04aBreakable.uasset`). These files define the visual and physical properties of these objects. [[1]](diffhunk://#diff-887da9f89f523929f7a68af4ebba01ac176551bcc08c5063051ed5dd0ebd36fbR1-R3) [[2]](diffhunk://#diff-7f3b8c30aae181013bb1257f1e0e86a7b8b19ff453647c2bc826ae8466b5b4a1R1-R3) [[3]](diffhunk://#diff-19a44d5be9ca01ade96f9baa4890251e6f341e2d094cbee3da01b371453fea33R1-R3) [[4]](diffhunk://#diff-55be813529e29c2ed9eff1f4f6fb02d62376a154f41d9a2da8d7662bc5d8163bR1-R3) [[5]](diffhunk://#diff-ae21d734d584d773f4c80db2ca3876fbc6698028ff9cd15a46b29e4b0f2c09a3R1-R3) [[6]](diffhunk://#diff-e78a7b719f0accf2a6636b97e0a2c81d0acc22cf65dce22d36489675a18a8d85R1-R3) [[7]](diffhunk://#diff-506ed375ca04743bd71bba95f978a22467ae2af1def4e19d6d581de622e5f32bR1-R3)
* Added destructible geometry collection files for these breakable objects (`GC_SM_ClayPot_01.uasset`, `GC_SM_ClayPot_02.uasset`, `GC_SM_Pot_B_Complete.uasset`, `GC_SM_Pot_C_Complete.uasset`, `GC_SM_Urn_01a.uasset`, `GC_SM_Urn_04a.uasset`) to define their destruction behavior. [[1]](diffhunk://#diff-898b8e755d6fc7f1c1fbd5f86fbd4eae8ede72c059987c35097cd7925bfd809eR1-R3) [[2]](diffhunk://#diff-30761b2c365e455da078e75c59813c57a7fe38c9c22e18e52215b195701e462bR1-R3) [[3]](diffhunk://#diff-2dc2495212a8fdea0f02f983ab6ac646dfe34709a014751f762c0f0bda6a2ddfR1-R3) [[4]](diffhunk://#diff-350746bd0b0fe9b1dfab257e574359df76d702a7c61f152c3e53c50c8f78dbf5R1-R3) [[5]](diffhunk://#diff-d94b5d83ea4f531859d4527818052e4e3c47743887ffcb17894df9117601237bR1-R3) [[6]](diffhunk://#diff-aa94ebb61b296795c4c6af4d0749fd9af58fc3636d84d04ea574e261751c1cdaR1-R3)
* Introduced new C++ classes (`ClayPot01Breakable`, `ClayPot02Breakable`) inheriting from `ABaseBreakable` to implement the behavior of specific breakable objects. These classes set up geometry collections and collision properties. [[1]](diffhunk://#diff-4a27223f2d3da9ad007d21de836711e234baadd7107f5cf0ef7b7b817a3e13f1R1-R15) [[2]](diffhunk://#diff-abf756880abe835aa91518677aa4c50a9f5af4c5f4f2adf0e88f5d7e67be5560R1-R17) [[3]](diffhunk://#diff-2e5b4c3baf1ac4b4dac1b3194630bd7d682ddd0f5128837e0e0fc5207f687405R1-R15)

### Map and Workspace Updates:
* Updated the `MainMap.umap` file to reference new assets, increasing its size slightly.
* Modified the `Delta.code-workspace` file to associate `.rh` files with the C++ language for better editor support.

### Asset Removal:
* Removed the outdated `BP_Pot_A_Complete.uasset` file, likely replaced by the new `BP_PotACompleteBreakable.uasset`.