### PR TITLE
enemy: add healthbar

### DIFF
--- a/Content/Delta/HUD/WBP_HealthBar.uasset
+++ b/Content/Delta/HUD/WBP_HealthBar.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be81bae8983eed691f504141722a675bceb0941282f54a7a98f4853cd9fb0d8
+size 26026

--- a/Source/Delta/Common/Finder.h
+++ b/Source/Delta/Common/Finder.h
@@ -182,3 +182,18 @@
     NiagaraSystem->SetAsset(Finder.Object);                                                                \
   } while (false)
 // ----
+
+#define DELTA_SET_USER_WIDGET(WidgetComponent, WidgetClassPath)                                             \
+  do {                                                                                                      \
+    if (!(WidgetComponent) || !(WidgetClassPath)) {                                                         \
+      DELTA_LOG("{}", DeltaFormat("WidgetComponent is null or WidgetClassPath is null"));                   \
+      break;                                                                                                \
+    }                                                                                                       \
+    static ConstructorHelpers::FClassFinder<UUserWidget> Finder(WidgetClassPath);                           \
+    if (!Finder.Succeeded()) {                                                                              \
+      DELTA_LOG("{}", DeltaFormat("Failed to load user widget class: {}", TCHAR_TO_UTF8(WidgetClassPath))); \
+      break;                                                                                                \
+    }                                                                                                       \
+    WidgetComponent->SetWidgetClass(Finder.Class);                                                          \
+  } while (false)
+// ----

--- a/Source/Delta/Enemy/Enemy.cpp
+++ b/Source/Delta/Enemy/Enemy.cpp
@@ -73,6 +73,9 @@ AEnemy::AEnemy() {
     HealthBarWidget->SetupAttachment(GetRootComponent());
     HealthBarWidget->SetRelativeLocation(FVector(0.0f, 0.0f, 80.0f));
     HealthBarWidget->SetWidgetSpace(EWidgetSpace::Screen);
+
+    static constexpr const TCHAR* const Path{TEXT("/Script/UMGEditor.WidgetBlueprint'/Game/Delta/HUD/WBP_HealthBar.WBP_HealthBar_C'")};
+    DELTA_SET_USER_WIDGET(HealthBarWidget, Path);
   }
 }
 

--- a/Source/Delta/HUD/HealthBar.cpp
+++ b/Source/Delta/HUD/HealthBar.cpp
@@ -20,12 +20,12 @@ void UHealthBar::NativePreConstruct() {
   if (HealthBar) {
     HealthBar->SetPercent(0.5f);
     HealthBar->SetBarFillType(EProgressBarFillType::Type::LeftToRight);
-  }
 
-  CanvasSlot = Cast<UCanvasPanelSlot>(HealthBar->Slot);
-  if (CanvasSlot) {
-    CanvasSlot->SetSize(FVector2D(180.0f, 13.0f));
-    CanvasSlot->SetAnchors(FAnchors(0.5f, 0.5f, 0.5f, 0.5f));
-    CanvasSlot->SetAlignment(FVector2D(0.5f, 0.5f));
+    CanvasSlot = Cast<UCanvasPanelSlot>(HealthBar->Slot);
+    if (CanvasSlot) {
+      CanvasSlot->SetSize(FVector2D(180.0f, 13.0f));
+      CanvasSlot->SetAnchors(FAnchors(0.5f, 0.5f, 0.5f, 0.5f));
+      CanvasSlot->SetAlignment(FVector2D(0.5f, 0.5f));
+    }
   }
 }

--- a/Source/Delta/HUD/HealthBar.cpp
+++ b/Source/Delta/HUD/HealthBar.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#include "HealthBar.h"
+#include "Components/ProgressBar.h"
+#include "Components/CanvasPanelSlot.h"
+
+UHealthBar::UHealthBar(const FObjectInitializer& ObjectInitializer)
+  : Super(ObjectInitializer) {
+}
+
+void UHealthBar::NativeConstruct() {
+  Super::NativeConstruct();
+}
+
+void UHealthBar::NativePreConstruct() {
+  Super::NativePreConstruct();
+
+  if (HealthBar) {
+    HealthBar->SetPercent(0.5f);
+    HealthBar->SetBarFillType(EProgressBarFillType::Type::LeftToRight);
+  }
+
+  CanvasSlot = Cast<UCanvasPanelSlot>(HealthBar->Slot);
+  if (CanvasSlot) {
+    CanvasSlot->SetSize(FVector2D(180.0f, 13.0f));
+    CanvasSlot->SetAnchors(FAnchors(0.5f, 0.5f, 0.5f, 0.5f));
+    CanvasSlot->SetAlignment(FVector2D(0.5f, 0.5f));
+  }
+}

--- a/Source/Delta/HUD/HealthBar.h
+++ b/Source/Delta/HUD/HealthBar.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "HealthBar.generated.h"
+
+class UProgressBar;
+class UCanvasPanelSlot;
+
+UCLASS()
+class DELTA_API UHealthBar : public UUserWidget {
+  GENERATED_BODY()
+
+public:
+  UHealthBar(const FObjectInitializer& ObjectInitializer);
+
+  UPROPERTY(meta = (BindWidget))
+  TObjectPtr<UProgressBar> HealthBar;
+
+  UPROPERTY()
+  TObjectPtr<UCanvasPanelSlot> CanvasSlot;
+
+protected:
+  virtual void NativeConstruct() override;
+  virtual void NativePreConstruct() override;
+};


### PR DESCRIPTION
This pull request introduces a new `UHealthBar` class to manage the health bar widget in the HUD and integrates it into the enemy system. The changes include the addition of the `UHealthBar` class, updates to the enemy initialization logic, and a new macro for setting user widgets. Below is a breakdown of the most important changes:

### HUD Enhancements:
* Added a new `UHealthBar` class in `Source/Delta/HUD/HealthBar.h` and `Source/Delta/HUD/HealthBar.cpp`. This class extends `UUserWidget` and includes properties for a `UProgressBar` and `UCanvasPanelSlot`, along with methods to configure the health bar's appearance and behavior during construction. [[1]](diffhunk://#diff-660a8586a9c837291e63b95952f3c0d0e1a4520b4e26020d1f090b3035086f1dR1-R30) [[2]](diffhunk://#diff-ada6f4d7f90d2dc0ee1d0f9fc70cd77693f835bc38e712e6f2780e0ca4670caaR1-R31)

### Enemy Integration:
* Updated the `AEnemy` constructor in `Source/Delta/Enemy/Enemy.cpp` to initialize the health bar widget using a new macro. The health bar widget is now loaded dynamically from the specified path.

### Utility Macro:
* Added the `DELTA_SET_USER_WIDGET` macro in `Source/Delta/Common/Finder.h`. This macro simplifies the process of setting a widget class for a widget component, with error handling and logging for invalid inputs or failed widget class loading.

### Asset Management:
* Added a new asset reference for the health bar widget blueprint (`WBP_HealthBar`) in `Content/Delta/HUD/WBP_HealthBar.uasset`. This asset is used by the `UHealthBar` class.