### PR TITLE
health bar: use texture

### DIFF
--- a/Content/Delta/HUD/WBP_HealthBar.uasset
+++ b/Content/Delta/HUD/WBP_HealthBar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1be81bae8983eed691f504141722a675bceb0941282f54a7a98f4853cd9fb0d8
-size 26026
+oid sha256:9d828b23be8c47821f16f48b6da159f799ff46084090e8b3f44d6802e43872f3
+size 31039

--- a/Content/Delta/Map/MainMap.umap
+++ b/Content/Delta/Map/MainMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b134602c86442e3777efa00f89ea974270fa6e93a3e9208d08868cfa449f2c75
-size 359063
+oid sha256:ef37250b8d6bc018fde2dd378db8701075c302ff80ed7c58b9f5fc62ef60af9d
+size 359650

--- a/Content/Texture/HealthBar/Medium_Enemy_Front.uasset
+++ b/Content/Texture/HealthBar/Medium_Enemy_Front.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfcfa7e8730422a98f5294424b697c2afd7ae75d04a3877bfa03740f09e4c27e
+size 12613

--- a/Content/Texture/HealthBar/Medium_Health_Fill.uasset
+++ b/Content/Texture/HealthBar/Medium_Health_Fill.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5333685ea34a9295e6c9010f39f4ed9883f0ad0d9a9ccbf936ef13cc2de54e5a
+size 11705

--- a/Source/Delta/Delta.Build.cs
+++ b/Source/Delta/Delta.Build.cs
@@ -29,6 +29,7 @@ public class Delta : ModuleRules
       "MetasoundGraphCore",
       "GeometryCollectionEngine",
       "UMG",
+      "SlateCore",
     });
 
     PrivateDependencyModuleNames.AddRange(new string[] { });

--- a/Source/Delta/HUD/HealthBar.cpp
+++ b/Source/Delta/HUD/HealthBar.cpp
@@ -5,6 +5,8 @@
 #include "HealthBar.h"
 #include "Components/ProgressBar.h"
 #include "Components/CanvasPanelSlot.h"
+#include "Components/Image.h"
+#include "Styling/SlateBrush.h"
 
 UHealthBar::UHealthBar(const FObjectInitializer& ObjectInitializer)
   : Super(ObjectInitializer) {
@@ -18,12 +20,43 @@ void UHealthBar::NativePreConstruct() {
   Super::NativePreConstruct();
 
   if (HealthBar) {
+    static const TCHAR* const Path          = TEXT("/Game/Texture/HealthBar/Medium_Health_Fill.Medium_Health_Fill");
+    static auto* const        LoadedTexture = Cast<UTexture2D>(StaticLoadObject(UTexture2D::StaticClass(), nullptr, Path));
+
+    if (LoadedTexture != nullptr) {
+      FillImage = LoadedTexture;
+      FSlateBrush NewBrush;
+      NewBrush.SetResourceObject(FillImage);
+      HealthBar->WidgetStyle.SetFillImage(NewBrush);
+      HealthBar->WidgetStyle.BackgroundImage.TintColor = FLinearColor(1.0f, 1.0f, 1.0f, 0.0f);
+    }
+
     HealthBar->SetBarFillType(EProgressBarFillType::Type::LeftToRight);
     HealthBar->SetPercent(1.0f);
+    HealthBar->SetFillColorAndOpacity(FLinearColor(1.0f, 1.0f, 1.0f, 1.0f));
 
     CanvasSlot = Cast<UCanvasPanelSlot>(HealthBar->Slot);
     if (CanvasSlot) {
       CanvasSlot->SetSize(FVector2D(180.0f, 13.0f));
+      CanvasSlot->SetAnchors(FAnchors(0.5f, 0.5f, 0.5f, 0.5f));
+      CanvasSlot->SetAlignment(FVector2D(0.5f, 0.5f));
+    }
+  }
+
+  if (BorderImage) {
+    static const TCHAR* const Path          = TEXT("/Game/Texture/HealthBar/Medium_Enemy_Front.Medium_Enemy_Front");
+    static auto* const        LoadedTexture = Cast<UTexture2D>(StaticLoadObject(UTexture2D::StaticClass(), nullptr, Path));
+
+    if (LoadedTexture != nullptr) {
+      BackgroundImage = LoadedTexture;
+      FSlateBrush NewBrush;
+      NewBrush.SetResourceObject(BackgroundImage);
+      BorderImage->SetBrush(NewBrush);
+    }
+
+    CanvasSlot = Cast<UCanvasPanelSlot>(BorderImage->Slot);
+    if (CanvasSlot) {
+      CanvasSlot->SetSize(FVector2D(183.0f, 13.0f));
       CanvasSlot->SetAnchors(FAnchors(0.5f, 0.5f, 0.5f, 0.5f));
       CanvasSlot->SetAlignment(FVector2D(0.5f, 0.5f));
     }

--- a/Source/Delta/HUD/HealthBar.h
+++ b/Source/Delta/HUD/HealthBar.h
@@ -10,6 +10,7 @@
 
 class UProgressBar;
 class UCanvasPanelSlot;
+class UImage;
 
 UCLASS()
 class DELTA_API UHealthBar : public UUserWidget {
@@ -18,8 +19,11 @@ class DELTA_API UHealthBar : public UUserWidget {
 public:
   UHealthBar(const FObjectInitializer& ObjectInitializer);
 
-  UPROPERTY(meta = (BindWidget))
+  UPROPERTY(meta = (BindWidget), EditAnywhere)
   TObjectPtr<UProgressBar> HealthBar;
+
+  UPROPERTY(meta = (BindWidget), EditAnywhere)
+  TObjectPtr<UImage> BorderImage;
 
   UPROPERTY()
   TObjectPtr<UCanvasPanelSlot> CanvasSlot;
@@ -27,4 +31,10 @@ public:
 protected:
   virtual void NativeConstruct() override;
   virtual void NativePreConstruct() override;
+
+  UPROPERTY()
+  TObjectPtr<UTexture2D> FillImage;
+
+  UPROPERTY()
+  TObjectPtr<UTexture2D> BackgroundImage;
 };


### PR DESCRIPTION
This pull request introduces enhancements to the health bar system in the HUD, updates textures, and makes adjustments to dependencies. The most important changes include adding new textures for the health bar, updating the `HealthBar` class to support these textures, and modifying dependencies to include `SlateCore`. Below is a detailed breakdown:

### Health Bar Enhancements:
* Updated `HealthBar.cpp` to dynamically load and apply new textures (`Medium_Health_Fill` and `Medium_Enemy_Front`) for the health bar's fill and border images. This includes setting up `FSlateBrush` objects and configuring the `HealthBar` widget's style and appearance. [[1]](diffhunk://#diff-ada6f4d7f90d2dc0ee1d0f9fc70cd77693f835bc38e712e6f2780e0ca4670caaR23-R36) [[2]](diffhunk://#diff-ada6f4d7f90d2dc0ee1d0f9fc70cd77693f835bc38e712e6f2780e0ca4670caaR45-R63)
* Modified `HealthBar.h` to include new properties (`FillImage`, `BackgroundImage`, and `BorderImage`) for managing the textures and added `EditAnywhere` to allow configuration in the editor. [[1]](diffhunk://#diff-660a8586a9c837291e63b95952f3c0d0e1a4520b4e26020d1f090b3035086f1dR13) [[2]](diffhunk://#diff-660a8586a9c837291e63b95952f3c0d0e1a4520b4e26020d1f090b3035086f1dL21-R39)

### Texture Additions:
* Added new texture assets: `Medium_Health_Fill.uasset` and `Medium_Enemy_Front.uasset`, which are used for the health bar's appearance. [[1]](diffhunk://#diff-469024622d96045464cc892868a17dacaebf83ce6e30f01c56f1f5074ca6c5b9R1-R3) [[2]](diffhunk://#diff-9f49ddc559fa085a3cea3e0c82c51f85ac831f7d43e9c6052627a37fb9122afaR1-R3)

### Dependency Updates:
* Added `SlateCore` to the public dependency modules in `Delta.Build.cs` to support the use of `FSlateBrush` and related Slate UI components.

### Asset Updates:
* Updated the `WBP_HealthBar.uasset` and `MainMap.umap` files to reflect changes in the health bar and map configurations. These updates likely include adjustments to integrate the new textures and functionality. [[1]](diffhunk://#diff-c6d91aa74d1b89853581b932a54b8a858f5037cde8cbad130644b12f88dd841bL2-R3) [[2]](diffhunk://#diff-74a41c9ea291a9253cd727a50d97653337b0c9a4242145874d7937c14480873eL2-R3)