### PR TITLE
enemy: handle death state

### DIFF
--- a/Assets/README.md
+++ b/Assets/README.md
@@ -75,7 +75,37 @@
       - Skin: Without Skin
       - FPS: 30
       - Keyframe Reduction: none 
-
+    - Sword And Shield Death
+      - Format: *.fbx
+      - Skin: With Skin
+      - FPS: 30
+      - Keyframe Reduction: none 
+    - Sword And Shield Death (other)
+      - Format: *.fbx
+      - Skin: Withouth Skin
+      - FPS: 30
+      - Keyframe Reduction: none 
+    - Falling Back Death
+      - Format: *.fbx
+      - Skin: Withouth Skin
+      - FPS: 30
+      - Keyframe Reduction: none 
+    - Falling Forward Death
+      - Format: *.fbx
+      - Skin: Withouth Skin
+      - FPS: 30
+      - Keyframe Reduction: none 
+    - Flying Back Death
+      - Format: *.fbx
+      - Skin: Withouth Skin
+      - FPS: 30
+      - Keyframe Reduction: none 
+    - Standing Death Right 01
+      - Format: *.fbx
+      - Skin: Withouth Skin
+      - FPS: 30
+      - Keyframe Reduction: none 
+      
 ## Effects
 - https://github.com/DruidMech/UE5_TheUltimateDeveloperCourse/tree/main/Downloads/Effects
 

--- a/Content/Delta/Enemy/Animation/Montage/AM_Death.uasset
+++ b/Content/Delta/Enemy/Animation/Montage/AM_Death.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7884bfff3aabe43d5e27e7f352d87c2c64b8b536ca3f6c23eeecc65e5a9486ea
+size 13048

--- a/Content/Delta/Enemy/Animation/Sequence/Death/Falling_Back_Death.uasset
+++ b/Content/Delta/Enemy/Animation/Sequence/Death/Falling_Back_Death.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:352fa485f093ef3bd2ee1ca43f7f8de5d1e41f8c32b1923cbf931d3123e5e754
+size 494429

--- a/Content/Delta/Enemy/Animation/Sequence/Death/Falling_Forward_Death.uasset
+++ b/Content/Delta/Enemy/Animation/Sequence/Death/Falling_Forward_Death.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86c1fbe81d491e52c32f240dbbe5958b358d3f9b3e47f9584c28f7d031da0736
+size 491010

--- a/Content/Delta/Enemy/Animation/Sequence/Death/Flying_Back_Death.uasset
+++ b/Content/Delta/Enemy/Animation/Sequence/Death/Flying_Back_Death.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2ac709cd34e2cb62dd6e472f2f2ffa3c9be177d0bc818e489e8e2db4b42abc6
+size 552336

--- a/Content/Delta/Enemy/Animation/Sequence/Death/Standing_Death_Right_01.uasset
+++ b/Content/Delta/Enemy/Animation/Sequence/Death/Standing_Death_Right_01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9e87f21bf2ddbf4a7724b6806b6ceb6658bdd25a4eaae4268c1d3c209b543b9
+size 428790

--- a/Content/Delta/Enemy/Animation/Sequence/Death/Sword_And_Shield_Death_1.uasset
+++ b/Content/Delta/Enemy/Animation/Sequence/Death/Sword_And_Shield_Death_1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3f963ed10d15ea19a4548eaa8f9a25df2bb1895c9ada8d4ebad8d4395a0ecb
+size 497603

--- a/Content/Delta/Enemy/Animation/Sequence/Death/Sword_And_Shield_Death_2.uasset
+++ b/Content/Delta/Enemy/Animation/Sequence/Death/Sword_And_Shield_Death_2.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:296c2c2a83b2c6a87806e60b1dd7fd8f4cc015a7269cf4842b22b3db3f53cb53
+size 366969

--- a/Docs/Blender/Mixamo Converter.png
+++ b/Docs/Blender/Mixamo Converter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3274f66c6423db0b1b94ad7e208d03b23b67f4e5058897245f518bd9327a6303
+size 84595

--- a/Source/Delta/Enemy/Enemy.cpp
+++ b/Source/Delta/Enemy/Enemy.cpp
@@ -128,7 +128,7 @@ void AEnemy::Die() {
 
     HideHealthBar();
     GetCapsuleComponent()->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-    SetLifeSpan(10.f);
+    SetLifeSpan(DeathLifeSpanSeconds);
   }
 }
 

--- a/Source/Delta/Enemy/Enemy.h
+++ b/Source/Delta/Enemy/Enemy.h
@@ -67,4 +67,7 @@ protected:
 
   UPROPERTY(EditAnywhere)
   double CombatRadius{500.f};
+
+  UPROPERTY();
+  float DeathLifeSpanSeconds{10.f};
 };

--- a/Source/Delta/Enemy/Enemy.h
+++ b/Source/Delta/Enemy/Enemy.h
@@ -6,6 +6,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Character.h"
+#include "EnemyState.h"
 #include "../Character/BaseCharacter.h"
 #include "../Interface/HitInterface.h"
 #include "Enemy.generated.h"
@@ -38,15 +39,32 @@ public:
 
   void DirectionalHitReact(const FVector& ImpactPoint);
 
+  void HideHealthBar();
+  void ShowHealthBar();
+
 protected:
   virtual void BeginPlay() override;
 
+  void Die();
+
   UPROPERTY(EditDefaultsOnly, Category = "Montages")
   TObjectPtr<UAnimMontage> HitReactMontage;
+
+  UPROPERTY(EditDefaultsOnly, Category = "Montages")
+  TObjectPtr<UAnimMontage> DeathMontage;
 
   UPROPERTY(VisibleAnywhere, Category = "Attributes")
   TObjectPtr<UAttributeComponent> AttributeComponent;
 
   UPROPERTY(EditAnywhere, Category = "Widgets")
   TObjectPtr<UHealthBarComponent> HealthBarComponent;
+
+  UPROPERTY(BlueprintReadOnly)
+  EDeathPose DeathPose = EDeathPose::EDP_Alive;
+
+  UPROPERTY()
+  TObjectPtr<AActor> CombatTarget;
+
+  UPROPERTY(EditAnywhere)
+  double CombatRadius{500.f};
 };

--- a/Source/Delta/Enemy/EnemyState.h
+++ b/Source/Delta/Enemy/EnemyState.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 Gapry.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+#pragma once
+
+UENUM(BlueprintType)
+enum class EDeathPose : uint8 {
+  EDP_Alive                UMETA(DisplayName = "Alive"),
+  EDP_Death_FallingBack    UMETA(DisplayName = "DeathFallingBack"),
+  EDP_Death_FallingForward UMETA(DisplayName = "DeathFallingForward"),
+  EDP_Death_FlyingBack     UMETA(DisplayName = "DeathFlyingBack"),
+  EDP_Death_ToRight        UMETA(DisplayName = "DeathToRight"),
+  EDP_Death_ToFront        UMETA(DisplayName = "DeathToFront"),
+  EDP_Death_ToBack         UMETA(DisplayName = "DeathToBack")
+};

--- a/Source/Delta/HUD/HealthBar.cpp
+++ b/Source/Delta/HUD/HealthBar.cpp
@@ -32,7 +32,6 @@ void UHealthBar::NativePreConstruct() {
     }
 
     HealthBar->SetBarFillType(EProgressBarFillType::Type::LeftToRight);
-    HealthBar->SetPercent(1.0f);
     HealthBar->SetFillColorAndOpacity(FLinearColor(1.0f, 1.0f, 1.0f, 1.0f));
 
     CanvasSlot = Cast<UCanvasPanelSlot>(HealthBar->Slot);

--- a/Source/Delta/Weapon/Sword.cpp
+++ b/Source/Delta/Weapon/Sword.cpp
@@ -123,13 +123,13 @@ void ASword::OnWeaponBoxBeginOverlap(UPrimitiveComponent* OverlappedComponent,
                                        true);                                 // bIgnoreSelf
 
   if (auto* const BoxHitActor = BoxHit.GetActor(); BoxHitActor != nullptr) {
+    UGameplayStatics::ApplyDamage(BoxHitActor, Damage, GetInstigator()->GetController(), this, UDamageType::StaticClass());
     IHitInterface* const HitInterface = Cast<IHitInterface>(BoxHitActor);
     if (HitInterface != nullptr) {
       HitInterface->GetHit(BoxHit.ImpactPoint);
     }
     IgnoreActors.AddUnique(BoxHitActor);
     CreateAttackFields(BoxHit.ImpactPoint);
-    UGameplayStatics::ApplyDamage(BoxHitActor, Damage, GetInstigator()->GetController(), this, UDamageType::StaticClass());
   }
 }
 


### PR DESCRIPTION
This pull request introduces several enhancements and features related to enemy death animations, health bar visibility, and combat mechanics. It adds new death animation assets, integrates them into the enemy class, and introduces a system for handling enemy death states. Additionally, it refines health bar behavior and fixes the order of damage application in weapon overlap logic.

### Animation and Death System Enhancements:
* Added new death animation assets, including `Sword And Shield Death`, `Falling Back Death`, `Falling Forward Death`, `Flying Back Death`, and `Standing Death Right 01` (`*.uasset` files). These animations are now referenced in the `Assets/README.md` file. [[1]](diffhunk://#diff-b07e6a58f34fb3c20b40429ddbda92f50d4ac1606721bc546d76ccc2672fb17bR78-R107) [[2]](diffhunk://#diff-ab4054e065678921745827b2af7ffe9739c0c070a03a2f2c5cc601939875d7deR1-R3) [[3]](diffhunk://#diff-3b543c3c2bb517d2320423327124875564cef8d4f26112ab9338e57258467d4fR1-R3) [[4]](diffhunk://#diff-11b16118e84044efa5b677e8edca982bedc4512e63a48b07cca82e04fd29aebeR1-R3) [[5]](diffhunk://#diff-d576e41881ad2b20da77af6d1ae3dbc9f556f8e13d026c74702ce3362c36d9d7R1-R3) [[6]](diffhunk://#diff-68ce29e986cc4bc154ce9c703df8a81c2d1b9d6808dafea2c3cea06b17ac5ddcR1-R3) [[7]](diffhunk://#diff-290d41431e65ed02cda3242ea3eb8ef7d64b4eac817b75686397aa84eaee3dffR1-R3) [[8]](diffhunk://#diff-9d7a36ca8e097ff2251eeda0e2ad915a6f860441188fa1649100ea93bd8adb78R1-R3)
* Integrated a new `DeathMontage` animation montage into the `AEnemy` class, with logic to randomly select and play a death animation section based on predefined poses. [[1]](diffhunk://#diff-4cb44603d3a04edbf5e35294b2302f24aa505893e313fe61f269da132c89c943R67-R71) [[2]](diffhunk://#diff-4cb44603d3a04edbf5e35294b2302f24aa505893e313fe61f269da132c89c943R89-R144)
* Added the `EDeathPose` enum to represent various death states, such as falling back or flying back, for better animation handling.

### Health Bar Visibility Improvements:
* Added `HideHealthBar` and `ShowHealthBar` methods to the `AEnemy` class, ensuring the health bar is hidden upon death and shown when the enemy takes damage. [[1]](diffhunk://#diff-4cb44603d3a04edbf5e35294b2302f24aa505893e313fe61f269da132c89c943R213-R224) [[2]](diffhunk://#diff-fe96e1ec90e013ea3b02dcaf13f957240878e60bb8fd9ded567fda3f1a39e92dR42-R69)
* Removed the default health bar percentage initialization in `UHealthBar::NativePreConstruct` to avoid unnecessary overrides.

### Combat and Damage Logic Refinements:
* Fixed the order of operations in `ASword::OnWeaponBoxBeginOverlap` by ensuring damage is applied before triggering hit reactions or adding actors to the ignore list.

These changes collectively enhance the game's visual and gameplay experience by improving how enemies react to damage and death, while also addressing minor logic issues.