### PR TITLE
player: increase the attack rate

### DIFF
--- a/Source/Delta/Player/Echo/EchoCharacter.cpp
+++ b/Source/Delta/Player/Echo/EchoCharacter.cpp
@@ -363,7 +363,10 @@ void AEchoCharacter::PlayAttackMontage() {
     return;
   }
 
-  AnimInstance->Montage_Play(AttackMontage);
+  const float DefaultPlayRate = AttackMontage->RateScale;
+  const float NewPlayRate     = DefaultPlayRate * 1.5f;
+
+  AnimInstance->Montage_Play(AttackMontage, NewPlayRate);
 
   const int32  Selection   = FMath::RandRange(0, 2);
   static FName SectionName = FName();

--- a/Source/Delta/Player/Echo/EchoCharacter.cpp
+++ b/Source/Delta/Player/Echo/EchoCharacter.cpp
@@ -363,8 +363,9 @@ void AEchoCharacter::PlayAttackMontage() {
     return;
   }
 
+  const float AttackScalar    = 1.5f;
   const float DefaultPlayRate = AttackMontage->RateScale;
-  const float NewPlayRate     = DefaultPlayRate * 1.5f;
+  const float NewPlayRate     = DefaultPlayRate * AttackScalar;
 
   AnimInstance->Montage_Play(AttackMontage, NewPlayRate);
 


### PR DESCRIPTION
This pull request includes a small but significant change in the `PlayAttackMontage` method of the `EchoCharacter` class to adjust the animation playback speed.

* [`Source/Delta/Player/Echo/EchoCharacter.cpp`](diffhunk://#diff-cb027d37392a0c3823dc44e529061175cc8d80b0ce5304a8c2b8c8b255eb6652L366-R369): Updated the `PlayAttackMontage` method to increase the play rate of the `AttackMontage` animation by 50%, using a new calculated play rate (`NewPlayRate`).