### PR TITLE
enemy: add weapon

### DIFF
--- a/Content/Mixamo/Paladin/Sword_And_Shield_Idle.uasset
+++ b/Content/Mixamo/Paladin/Sword_And_Shield_Idle.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29c8b83a156b111c7c0a27bde4fa2e6b1f8e03d94f9aea1d6d55209cfa681b80
+oid sha256:b187e019c2d2d222001b60d2b65635d3fb8e84e825cafcd28081f262bd248515
 size 2299902

--- a/Content/Mixamo/Paladin/Sword_And_Shield_Idle_Skeleton.uasset
+++ b/Content/Mixamo/Paladin/Sword_And_Shield_Idle_Skeleton.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88b4bb750f73aaf4981520516dccec19e123223e81a432aa42c422ad19ec5135
-size 22791
+oid sha256:da59bcaa7c7a3a614c846f15c2707e8fc15e2f5a81c49f418d5cf1d06a3a8d81
+size 23355

--- a/Source/Delta/Enemy/BaseEnemy.cpp
+++ b/Source/Delta/Enemy/BaseEnemy.cpp
@@ -26,6 +26,7 @@
 #include "../Component/AttributeComponent.h"
 #include "../Component/HealthBarComponent.h"
 #include "../Player/Echo/EchoCharacter.h"
+#include "../Weapon/Weapon.h"
 
 ABaseEnemy::ABaseEnemy() {
   {
@@ -259,6 +260,12 @@ float ABaseEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent
   GetCharacterMovement()->MaxWalkSpeed = UpperBoundSpeed;
   MoveToTarget(CombatTarget);
   return DamageAmount;
+}
+
+void ABaseEnemy::Destroyed() {
+  if (EquippedWeapon) {
+    EquippedWeapon->Destroy();
+  }
 }
 
 void ABaseEnemy::GetHit(const FVector& ImpactPoint) {

--- a/Source/Delta/Enemy/BaseEnemy.cpp
+++ b/Source/Delta/Enemy/BaseEnemy.cpp
@@ -263,6 +263,8 @@ float ABaseEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent
 }
 
 void ABaseEnemy::Destroyed() {
+  Super::Destroyed();
+  
   if (EquippedWeapon) {
     EquippedWeapon->Destroy();
   }

--- a/Source/Delta/Enemy/BaseEnemy.h
+++ b/Source/Delta/Enemy/BaseEnemy.h
@@ -22,6 +22,7 @@ class UHealthBarComponent;
 class AAIController;
 class UAIPerceptionComponent;
 class UAISenseConfig_Sight;
+class AWeapon;
 
 UCLASS()
 class DELTA_API ABaseEnemy : public ABaseCharacter {
@@ -38,6 +39,8 @@ public:
                            struct FDamageEvent const& DamageEvent,     //
                            class AController*         EventInstigator, //
                            AActor*                    DamageCauser) override;
+
+  virtual void Destroyed() override;
 
   void SetPatrolTargets(const FName& TargetTag);
 
@@ -127,6 +130,9 @@ protected:
 
   UPROPERTY();
   FTimerHandle PatrolTimer;
+
+  UPROPERTY(EditAnywhere)
+  TSubclassOf<class AWeapon> WeaponClass;
 
   EEnemyState EnemyState = EEnemyState::EES_Patrolling;
 

--- a/Source/Delta/Enemy/Paladin.cpp
+++ b/Source/Delta/Enemy/Paladin.cpp
@@ -9,6 +9,7 @@
 #include "GameFramework/SpringArmComponent.h"
 #include "../Common/Finder.h"
 #include "../Component/HealthBarComponent.h"
+#include "../Weapon/Sword.h"
 
 APaladin::APaladin() {
   {
@@ -90,5 +91,12 @@ void APaladin::PostInitializeComponents() {
   Super::PostInitializeComponents();
 
   FAttachmentTransformRules TransformRules(EAttachmentRule::SnapToTarget, true);
-  Shield->AttachToComponent(SkeletalMeshComponent.Get(), TransformRules, TEXT("RightHandSocket"));
+  Shield->AttachToComponent(SkeletalMeshComponent.Get(), TransformRules, TEXT("LeftHandSocket"));
+
+  WeaponClass = ASword::StaticClass();
+  if (UWorld* World = GetWorld(); World && WeaponClass) {
+    auto* const DefaultWeapon = World->SpawnActor<ASword>(WeaponClass);
+    DefaultWeapon->Equip(GetMesh(), FName("RightHandSocket"), this, this);
+    EquippedWeapon = DefaultWeapon;
+  }
 }


### PR DESCRIPTION
This pull request introduces updates to the enemy class hierarchy and associated assets in the project. The most significant changes include the addition of weapon handling functionality to the `ABaseEnemy` class, updates to the `APaladin` class to equip a sword, and modifications to Mixamo asset references.

### Gameplay Mechanics Enhancements:

* **Weapon Handling in `ABaseEnemy`:**
  - Added a `Destroyed` method to ensure that an equipped weapon is destroyed when the enemy is destroyed. (`Source/Delta/Enemy/BaseEnemy.cpp`, [Source/Delta/Enemy/BaseEnemy.cppR265-R270](diffhunk://#diff-6094e48519ad3527711dd446be0cd237d8467a019d33b7c79261a6e611705fceR265-R270))
  - Introduced a `WeaponClass` property to allow enemies to specify and spawn a weapon. (`Source/Delta/Enemy/BaseEnemy.h`, [Source/Delta/Enemy/BaseEnemy.hR134-R136](diffhunk://#diff-03d5257346d9c8f0ccba8626c28049fa13c744173de27b3bffe93f6acd993e9eR134-R136))
  - Declared a forward reference for `AWeapon` and overridden the `Destroyed` method in the `ABaseEnemy` class. (`Source/Delta/Enemy/BaseEnemy.h`, [[1]](diffhunk://#diff-03d5257346d9c8f0ccba8626c28049fa13c744173de27b3bffe93f6acd993e9eR25) [[2]](diffhunk://#diff-03d5257346d9c8f0ccba8626c28049fa13c744173de27b3bffe93f6acd993e9eR43-R44)

* **Sword Equipping in `APaladin`:**
  - Modified the shield attachment to the left hand and implemented logic to spawn and equip a sword in the right hand during component initialization. (`Source/Delta/Enemy/Paladin.cpp`, [Source/Delta/Enemy/Paladin.cppL93-R101](diffhunk://#diff-7c1fc9d2f5110e158b8303a2be1fc1a098b749f5c7c20ec289002afd931d9e32L93-R101))
  - Added a forward declaration for the `ASword` class. (`Source/Delta/Enemy/Paladin.cpp`, [Source/Delta/Enemy/Paladin.cppR12](diffhunk://#diff-7c1fc9d2f5110e158b8303a2be1fc1a098b749f5c7c20ec289002afd931d9e32R12))

### Asset Updates:

* **Mixamo Asset References:**
  - Updated the hash and size metadata for `Sword_And_Shield_Idle.uasset` and `Sword_And_Shield_Idle_Skeleton.uasset`. (`Content/Mixamo/Paladin/Sword_And_Shield_Idle.uasset`, [[1]](diffhunk://#diff-5bac259139ba048c013df153d732f9876b0894ba76df806bf969bfc746c707baL2-R2); `Content/Mixamo/Paladin/Sword_And_Shield_Idle_Skeleton.uasset`, [[2]](diffhunk://#diff-c8ef0448001e40633b1bfa44b3b4e53f95f010ee19a016a4ed8930b5c12a78ffL2-R3)